### PR TITLE
🐛 fix: 카카오톡 공유 썸네일 잘리는 문제 해결

### DIFF
--- a/src/components/LinkShare.ts
+++ b/src/components/LinkShare.ts
@@ -35,7 +35,7 @@ export function shareKakaoTalk(food: string, category: string) {
     content: {
       title: `오늘 메뉴는 ${food} 어때요?`,
       description: '',
-      imageUrl: `${HOME_URL}/assets/img/thumbnail.jpg`,
+      imageUrl: `${HOME_URL}/assets/img/thumbnail.jpg?v=2`,
       imageWidth: 400,
       imageHeight: 300,
       link: {


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- 카카오톡 공유 썸네일 잘리는 문제 해결 (url 변경)
